### PR TITLE
feat: implement setting the duty period in time instead of ratio

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 rock_library(i2clib
-    SOURCES I2CBus.cpp PCA9685.cpp
-    HEADERS I2CBus.hpp PCA9685.hpp
+    SOURCES I2CBus.cpp PCA9685.cpp PCA9685PWMConfiguration.cpp
+    HEADERS I2CBus.hpp PCA9685.hpp PCA9685PWMConfiguration.hpp
     DEPS_PKGCONFIG base-types
 )
 

--- a/src/Exceptions.hpp
+++ b/src/Exceptions.hpp
@@ -7,6 +7,9 @@ namespace i2clib {
     struct IOError : public std::runtime_error {
         using std::runtime_error::runtime_error;
     };
+    struct ReadError : public IOError {
+        using IOError::IOError;
+    };
     struct WriteError : public IOError {
         using IOError::IOError;
     };

--- a/src/I2CBus.hpp
+++ b/src/I2CBus.hpp
@@ -28,6 +28,31 @@ namespace i2clib {
          */
         void setTimeout(base::Time const& timeout);
 
+        /** Perform a transaction with a write followed by a read
+         *
+         * \c data contains information for the write. The read information is
+         * returned.
+         */
+        template <int Size> std::array<uint8_t, Size> read(uint8_t address, uint8_t reg)
+        {
+            std::array<uint8_t, Size> read_bytes;
+            uint8_t reg_rw{reg};
+
+            read(address, &reg_rw, 1, read_bytes.data(), read_bytes.size());
+            return read_bytes;
+        }
+
+        /** Perform a transaction with a write followed by a read
+         *
+         * \c data contains information for the write. The read information is
+         * returned.
+         */
+        void read(uint8_t address,
+            uint8_t* write_bytes,
+            size_t write_size,
+            uint8_t* bytes,
+            size_t size);
+
         /** Write \c size bytes at the given address
          */
         void write(uint8_t address, uint8_t* bytes, size_t size);

--- a/src/PCA9685.cpp
+++ b/src/PCA9685.cpp
@@ -147,10 +147,10 @@ uint32_t PCA9685::readPWMPeriod(float freq)
     return prescaleToPeriod(prescale, freq);
 }
 
-void PCA9685::writeDutyTimes(int pwm, vector<uint32_t> const& times, float freq)
+void PCA9685::writeDutyTimes(int pwm, vector<uint32_t> const& times, uint32_t period)
 {
     // Get the duration of a single PWM step (one of 4096)
-    uint32_t quanta = readPWMPeriod(freq) / 4096.0;
+    uint32_t quanta = period / 4096.0;
 
     PWMConfiguration configurations[PWM_COUNT];
     for (size_t i = 0; i < times.size(); ++i) {

--- a/src/PCA9685.cpp
+++ b/src/PCA9685.cpp
@@ -11,6 +11,7 @@
 
 using namespace std;
 using namespace i2clib;
+using PWMConfiguration = PCA9685PWMConfiguration;
 
 uint8_t PCA9685::periodToPrescale(uint32_t ns)
 {
@@ -25,6 +26,12 @@ uint8_t PCA9685::periodToPrescale(uint32_t ns)
     }
 
     return std::round(ns / denom) - 1;
+}
+
+uint32_t PCA9685::prescaleToPeriod(uint8_t prescale)
+{
+    float denom = OSCILLATOR_PERIOD_NS * 4096;
+    return (prescale + 1) * denom;
 }
 
 PCA9685::PCA9685(I2CBus& i2c, uint8_t address)
@@ -86,11 +93,11 @@ void PCA9685::pwmConfigurationToRegisters(uint8_t* registers,
     PWMConfiguration const& configuration)
 {
     switch (configuration.mode) {
-        case PWM_MODE_ON:
+        case PWMConfiguration::MODE_ON:
             registers[1] = PWM_FULL_ON;
             registers[3] = 0;
             return;
-        case PWM_MODE_OFF: {
+        case PWMConfiguration::MODE_OFF: {
             registers[1] = 0;
             registers[3] = PWM_FULL_OFF;
             return;
@@ -135,23 +142,33 @@ void PCA9685::writePWMConfigurations(int pwm,
     return writePWMConfigurations(pwm, configurations.data(), configurations.size());
 }
 
-void PCA9685::writeDutyCycles(int pwm, vector<float> const& ratios)
+uint32_t PCA9685::readPWMPeriod() {
+    uint8_t prescale = m_i2c.read<1>(m_address, REGISTER_PRESCALE).at(0);
+    return prescaleToPeriod(prescale);
+}
+
+void PCA9685::writeDutyTimes(int pwm, vector<uint32_t> const& times)
+{
+    // Get the duration of a single PWM step (one of 4096)
+    uint32_t quanta = readPWMPeriod() / 4096;
+
+    PWMConfiguration configurations[PWM_COUNT];
+    for (size_t i = 0; i < times.size(); ++i) {
+        auto& c{configurations[i]};
+        int32_t off_edge = times[i] / quanta - 1;
+        c = PWMConfiguration::fromUnnormalizedOffEdge(off_edge);
+    }
+
+    writePWMConfigurations(pwm, configurations, times.size());
+}
+
+void PCA9685::writeDutyRatios(int pwm, vector<float> const& ratios)
 {
     PWMConfiguration configurations[PWM_COUNT];
     for (size_t i = 0; i < ratios.size(); ++i) {
         auto& c{configurations[i]};
-        int32_t duty_cycle = round(ratios[i] * 4096);
-        if (duty_cycle <= 0) {
-            c.mode = PWM_MODE_OFF;
-        }
-        else if (duty_cycle >= 4096) {
-            c.mode = PWM_MODE_ON;
-        }
-        else {
-            c.mode = PWM_MODE_NORMAL;
-            c.on_edge = 0;
-            c.off_edge = duty_cycle - 1;
-        }
+        int32_t off_edge = round(ratios[i] * 4096) - 1;
+        c = PWMConfiguration::fromUnnormalizedOffEdge(off_edge);
     }
 
     writePWMConfigurations(pwm, configurations, ratios.size());

--- a/src/PCA9685.cpp
+++ b/src/PCA9685.cpp
@@ -13,9 +13,9 @@ using namespace std;
 using namespace i2clib;
 using PWMConfiguration = PCA9685PWMConfiguration;
 
-uint8_t PCA9685::periodToPrescale(uint32_t ns)
+uint8_t PCA9685::periodToPrescale(uint32_t ns, float freq)
 {
-    float denom = OSCILLATOR_PERIOD_NS * 4096;
+    double denom = 1e9 / freq * 4096;
     if (ns < 4 * denom) {
         throw std::invalid_argument(
             "PWM period too low (" + to_string(ns) + "ns, minimum is ~656us)");
@@ -28,10 +28,10 @@ uint8_t PCA9685::periodToPrescale(uint32_t ns)
     return std::round(ns / denom) - 1;
 }
 
-uint32_t PCA9685::prescaleToPeriod(uint8_t prescale)
+uint32_t PCA9685::prescaleToPeriod(uint8_t prescale, float freq)
 {
-    float denom = OSCILLATOR_PERIOD_NS * 4096;
-    return (prescale + 1) * denom;
+    double denom = 1e9 / freq * 4096;
+    return std::round((prescale + 1) * denom);
 }
 
 PCA9685::PCA9685(I2CBus& i2c, uint8_t address)
@@ -81,12 +81,6 @@ void PCA9685::writeMode1()
 void PCA9685::writeMode2()
 {
     m_i2c.write(m_address, {REGISTER_MODE2, m_mode2});
-}
-
-void PCA9685::writeCycleDuration(uint32_t ns)
-{
-    uint8_t prescale = periodToPrescale(ns);
-    m_i2c.write(m_address, {REGISTER_PRESCALE, prescale});
 }
 
 void PCA9685::pwmConfigurationToRegisters(uint8_t* registers,
@@ -142,15 +136,21 @@ void PCA9685::writePWMConfigurations(int pwm,
     return writePWMConfigurations(pwm, configurations.data(), configurations.size());
 }
 
-uint32_t PCA9685::readPWMPeriod() {
-    uint8_t prescale = m_i2c.read<1>(m_address, REGISTER_PRESCALE).at(0);
-    return prescaleToPeriod(prescale);
+void PCA9685::writePrescale(uint8_t prescale)
+{
+    m_i2c.write(m_address, {REGISTER_PRESCALE, prescale});
 }
 
-void PCA9685::writeDutyTimes(int pwm, vector<uint32_t> const& times)
+uint32_t PCA9685::readPWMPeriod(float freq)
+{
+    uint8_t prescale = m_i2c.read<1>(m_address, REGISTER_PRESCALE).at(0);
+    return prescaleToPeriod(prescale, freq);
+}
+
+void PCA9685::writeDutyTimes(int pwm, vector<uint32_t> const& times, float freq)
 {
     // Get the duration of a single PWM step (one of 4096)
-    uint32_t quanta = readPWMPeriod() / 4096;
+    uint32_t quanta = readPWMPeriod(freq) / 4096.0;
 
     PWMConfiguration configurations[PWM_COUNT];
     for (size_t i = 0; i < times.size(); ++i) {

--- a/src/PCA9685.hpp
+++ b/src/PCA9685.hpp
@@ -15,8 +15,12 @@ namespace i2clib {
      * on the auto-increment function to be enabled, and does not implement the restart
      * function (i.e. one has to stop all PWMs before stopping the chip)
      *
-     * The constructor will stop all PWMs, put the chip in sleep mode and set the
-     * chip configuration to the manufacturer's default plus the auto-increment enabled.
+     * The prescale parameter allows to change the duration of the PWM cycle -
+     * it is global, that is common to all PWM outputs. See \c writePrescale for
+     * a complete discussion.
+     *
+     * We recomment calling \c stop before \c writeSleep. Some devices are known to
+     * misbehave if the PWM is non-zero when the PWM generators are active.
      */
     class PCA9685 {
     public:
@@ -66,8 +70,21 @@ namespace i2clib {
     public:
         static constexpr float INTERNAL_OSCILLATOR_FREQUENCY = 25e6;
 
+        /** Compute the PWM period from the chip's prescale parameter
+         *
+         * See \c writePrescale's documentation for a discussion on the prescale
+         * parameter
+         *
+         * @see writePrescale
+         */
         static std::uint8_t periodToPrescale(std::uint32_t ns,
             float freq = INTERNAL_OSCILLATOR_FREQUENCY);
+
+        /** Compute the chip's prescale parameter that is closest to the given
+         * PWM period
+         *
+         * @see writePrescale
+         */
         static std::uint32_t prescaleToPeriod(std::uint8_t ns,
             float freq = INTERNAL_OSCILLATOR_FREQUENCY);
 
@@ -108,20 +125,32 @@ namespace i2clib {
          */
         void writeNormalMode();
 
-        /** Change the PWM cycle by writing the prescale parameter
+        /** Change the duration of the PWM cycle by writing the prescale parameter
          *
-         * See periodToPrescale and prescaleToPeriod for conversion between the
-         * PWM cycle period and the prescale parameter
+         * The chip needs to be in sleep mode to change this
+         *
+         * Internally, the chip allows for the selection of a PWM period based
+         * on a 'prescale' parameter that can be set from 3 to 255. The
+         * available periods depend on the oscillator frequency (25MHz by
+         * default, can be different if an external oscillator is selected). The
+         * chip's datasheet explains how to compute those.
+         *
+         * \c prescaleToPeriod finds the prescale parameter that is closest to a
+         * desired period (given the oscillator frequency). Note that this might
+         * not be the prescale parameter you want. Depending on the devices you
+         * are controlling with the PWM, you might need a period of "at least"
+         * some duration. The i2c_pca9685_ctl tool has `period-to-prescale` and
+         * `prescale-to-period` to help you play with the values and select the
+         * one that is appropriate.
          */
         void writePrescale(uint8_t prescale);
 
-        /** Write the configuration of a single PWM
+        /** Write the configuration of a contiguous set of PWMs
          *
-         * @param mode since on_edge and off_edge are transition times, these values
-         *   cannot represent the two extreme "ON" and "OFF" states. `mode` represents
-         *   them
-         * @param on_edge transition "time" (between 0 and 4095) between off and on
-         * @param off_edge transition "time" (between 0 and 4095) between on and off
+         * It configures the PWMs from `pwm` to `pwm + conf.size() - 1`
+         *
+         * @param pwm the start PWM (0-based)
+         * @param conf the PWM configurations
          */
         void writePWMConfigurations(int pwm, std::vector<PWMConfiguration> const& conf);
 

--- a/src/PCA9685.hpp
+++ b/src/PCA9685.hpp
@@ -64,10 +64,12 @@ namespace i2clib {
             size_t size);
 
     public:
-        static constexpr int OSCILLATOR_PERIOD_NS = 40;
+        static constexpr float INTERNAL_OSCILLATOR_FREQUENCY = 25e6;
 
-        static std::uint8_t periodToPrescale(std::uint32_t ns);
-        static std::uint32_t prescaleToPeriod(std::uint8_t ns);
+        static std::uint8_t periodToPrescale(std::uint32_t ns,
+            float freq = INTERNAL_OSCILLATOR_FREQUENCY);
+        static std::uint32_t prescaleToPeriod(std::uint8_t ns,
+            float freq = INTERNAL_OSCILLATOR_FREQUENCY);
 
         /** Create the driver and initialize the chip to defaults
          *
@@ -106,8 +108,12 @@ namespace i2clib {
          */
         void writeNormalMode();
 
-        /** Change the PWM cycle */
-        void writeCycleDuration(uint32_t ns);
+        /** Change the PWM cycle by writing the prescale parameter
+         *
+         * See periodToPrescale and prescaleToPeriod for conversion between the
+         * PWM cycle period and the prescale parameter
+         */
+        void writePrescale(uint8_t prescale);
 
         /** Write the configuration of a single PWM
          *
@@ -120,13 +126,15 @@ namespace i2clib {
         void writePWMConfigurations(int pwm, std::vector<PWMConfiguration> const& conf);
 
         /** Simplified interface to set the duty cycles in [0, 1] */
-        void writeDutyTimes(int pwm, std::vector<uint32_t> const& periods);
+        void writeDutyTimes(int pwm,
+            std::vector<uint32_t> const& periods,
+            float freq = INTERNAL_OSCILLATOR_FREQUENCY);
 
         /** Simplified interface to set the duty cycles in [0, 1] */
         void writeDutyRatios(int pwm, std::vector<float> const& cycles);
 
         /** Read the currently configured PWM period in nanoseconds */
-        uint32_t readPWMPeriod();
+        uint32_t readPWMPeriod(float freq = INTERNAL_OSCILLATOR_FREQUENCY);
     };
 }
 

--- a/src/PCA9685.hpp
+++ b/src/PCA9685.hpp
@@ -2,6 +2,7 @@
 #define I2CLIB_PCA9685_HPP
 
 #include <i2clib/I2CBus.hpp>
+#include <i2clib/PCA9685PWMConfiguration.hpp>
 
 #include <cstdint>
 #include <functional>
@@ -19,25 +20,7 @@ namespace i2clib {
      */
     class PCA9685 {
     public:
-        enum PWMMode {
-            PWM_MODE_OFF,
-            PWM_MODE_ON,
-            PWM_MODE_NORMAL
-        };
-
-        /** Configuration of a single PWM
-         *
-         * on_edge and off_edge are the timing (within a 4096-ticks cycle) of resp.
-         * the off->on transition and on->off transition.
-         *
-         * As such, they can't represent the "full ON" and "full OFF" state. The mode
-         * argument is meant for that.
-         */
-        struct PWMConfiguration {
-            PWMMode mode = PWM_MODE_OFF;
-            uint16_t on_edge = 0;
-            uint16_t off_edge = 0;
-        };
+        using PWMConfiguration = PCA9685PWMConfiguration;
 
     private:
         static constexpr uint8_t MODE1_ALLCALL_ENABLED = 1 << 0;
@@ -84,6 +67,7 @@ namespace i2clib {
         static constexpr int OSCILLATOR_PERIOD_NS = 40;
 
         static std::uint8_t periodToPrescale(std::uint32_t ns);
+        static std::uint32_t prescaleToPeriod(std::uint8_t ns);
 
         /** Create the driver and initialize the chip to defaults
          *
@@ -136,7 +120,13 @@ namespace i2clib {
         void writePWMConfigurations(int pwm, std::vector<PWMConfiguration> const& conf);
 
         /** Simplified interface to set the duty cycles in [0, 1] */
-        void writeDutyCycles(int pwm, std::vector<float> const& cycles);
+        void writeDutyTimes(int pwm, std::vector<uint32_t> const& periods);
+
+        /** Simplified interface to set the duty cycles in [0, 1] */
+        void writeDutyRatios(int pwm, std::vector<float> const& cycles);
+
+        /** Read the currently configured PWM period in nanoseconds */
+        uint32_t readPWMPeriod();
     };
 }
 

--- a/src/PCA9685.hpp
+++ b/src/PCA9685.hpp
@@ -154,10 +154,16 @@ namespace i2clib {
          */
         void writePWMConfigurations(int pwm, std::vector<PWMConfiguration> const& conf);
 
-        /** Simplified interface to set the duty cycles in [0, 1] */
+        /** Simplified interface to set the duty cycles in nanoseconds
+         *
+         * @param durations the duty durations in nanoseconds
+         * @param period the chip's known PWM period. Use \c readPeriod to
+         *   read it from the chip configuration, or if you are explicitly
+         *   setting the prescale parameter, use \c prescaleToPeriod
+         */
         void writeDutyTimes(int pwm,
-            std::vector<uint32_t> const& periods,
-            float freq = INTERNAL_OSCILLATOR_FREQUENCY);
+            std::vector<uint32_t> const& durations,
+            uint32_t period);
 
         /** Simplified interface to set the duty cycles in [0, 1] */
         void writeDutyRatios(int pwm, std::vector<float> const& cycles);

--- a/src/PCA9685Main.cpp
+++ b/src/PCA9685Main.cpp
@@ -14,30 +14,46 @@ static constexpr int ARG_INDEX_CMD = 3;
 void usage(string const& cmd, ostream& io)
 {
     io << "usage: " << cmd << " DEV ADDRESS CMD [ARGS]\n"
-       << "  set-period TIME_NS PWM period in nanoseconds\n"
-       << "     The command stops PWM generation and put the chip to sleep\n"
+       << "  period-to-prescale PERIOD [FREQ] display the closest prescale parameters\n"
+       << "    to achieve a given period. Pass the optional frequency parameter\n"
+       << "    (in MHz) when using an external oscillator that is not 25MHz\n"
+       << "  prescale-to-period FACTOR [FREQ] display the PWM period for a given\n"
+       << "    prescale parameter. Pass the optional frequency parameter (in MHz)\n"
+       << "    when using an external clock that is not 25MHz\n"
+       << "  set-prescale FACTOR change PWM period by writing the prescale parameter\n"
+       << "    The command stops PWM generation and put the chip to sleep\n"
        << "  restart perform the PWM generation restart after a sleep\n"
        << "  sleep put the chip to sleep\n"
        << "  enable-external-clock use an external clock instead of the internal one\n"
-       << "     The command stops PWM generation and put the chip to sleep\n"
+       << "    The command stops PWM generation and put the chip to sleep\n"
        << "  stop set all PWM outputs to zero\n"
        << "  wakeup wake the chip up after a sleep\n"
-       << "  set-duty-us PWM TIME_US where TIME_US is the ON time in microseconds\n"
+       << "  set-duty-us PWM TIME_US [FREQ] where PWM is the 0-based index of the PWM\n"
+       << "    output whose duty cycle is being changed and TIME_US is the ON time in\n"
+       << "    microseconds. Pass FREQ (in MHz) when using an external oscillator\n"
+       << "    whose frequency is not 25MHz\n"
        << "  set-duty-ratio PWM RATIO where RATIO is the ratio of the ON phase of \n"
-       << "       the PWM period, as a float between 0 and 1\n"
+       << "    the PWM period, as a float between 0 and 1\n"
        << flush;
 }
 
-void validateCmdArgc(string cmd, int argc, int expectedCmdArgs)
+vector<string> validateCmdArgc(int argc, char** argv, int min, int max)
 {
-    if (argc < expectedCmdArgs + ARGC_MIN) {
-        cerr << "not enough arguments to " << cmd << endl;
+    if (argc < min + ARGC_MIN) {
+        cerr << "not enough arguments to " << argv[ARG_INDEX_CMD] << endl;
         exit(1);
     }
-    else if (argc > expectedCmdArgs + ARGC_MIN) {
-        cerr << "too many arguments to " << cmd << endl;
+    else if (argc > max + ARGC_MIN) {
+        cerr << "too many arguments to " << argv[ARG_INDEX_CMD] << endl;
         exit(1);
     }
+
+    return vector<string>(argv + ARGC_MIN, argv + argc);
+}
+
+vector<string> validateCmdArgc(int argc, char** argv, int expected)
+{
+    return validateCmdArgc(argc, argv, expected, expected);
 }
 
 int main(int argc, char** argv)
@@ -54,6 +70,38 @@ int main(int argc, char** argv)
     string i2c_dev = argv[1];
     int address = stoi(argv[2]);
     string cmd = argv[ARG_INDEX_CMD];
+
+    if (cmd == "prescale-to-period") {
+        auto cmdArgs = validateCmdArgc(argc, argv, 1, 2);
+        uint8_t prescale = stoi(cmdArgs[0]);
+        float freq = PCA9685::INTERNAL_OSCILLATOR_FREQUENCY;
+        if (cmdArgs.size() == 2) {
+            freq = stof(cmdArgs[1]);
+        }
+        cout << PCA9685::prescaleToPeriod(prescale, freq) << " ns" << endl;
+        return 0;
+    }
+    else if (cmd == "period-to-prescale") {
+        auto cmdArgs = validateCmdArgc(argc, argv, 1, 2);
+        uint32_t period = stoi(cmdArgs[0]);
+        float freq = PCA9685::INTERNAL_OSCILLATOR_FREQUENCY;
+        if (cmdArgs.size() == 2) {
+            freq = stof(cmdArgs[1]);
+        }
+
+        uint8_t prescale = PCA9685::periodToPrescale(period, freq);
+        if (prescale > 3) {
+            cout << "prescale: " << prescale - 1 << ", "
+                 << "period: " << PCA9685::prescaleToPeriod(prescale - 1, freq) << "\n";
+        }
+        cout << "prescale: " << prescale << ", "
+             << "period: " << PCA9685::prescaleToPeriod(prescale, freq) << "\n";
+        if (prescale < 255) {
+            cout << "prescale: " << prescale + 1 << ", "
+                 << "period: " << PCA9685::prescaleToPeriod(prescale + 1, freq) << "\n";
+        }
+        return 0;
+    }
 
     I2CBus bus(i2c_dev);
 
@@ -77,24 +125,28 @@ int main(int argc, char** argv)
     else if (cmd == "wakeup") {
         chip.writeNormalMode();
     }
-    else if (cmd == "set-period") {
-        validateCmdArgc("set-period", argc, 1);
-        auto duration = stoi(argv[ARG_INDEX_CMD + 1]);
+    else if (cmd == "set-prescale") {
+        auto cmdArgs = validateCmdArgc(argc, argv, 1, 2);
+        auto prescale = stoi(cmdArgs[0]);
 
         chip.stop();
         chip.writeSleepMode();
-        chip.writeCycleDuration(duration);
+        chip.writePrescale(prescale);
     }
     else if (cmd == "set-duty-us") {
-        validateCmdArgc("set-duty-us", argc, 2);
-        auto pwm = stoi(argv[ARG_INDEX_CMD + 1]);
-        uint32_t period = stoi(argv[ARG_INDEX_CMD + 2]);
+        auto cmdArgs = validateCmdArgc(argc, argv, 2, 3);
+        auto pwm = stoi(cmdArgs[0]);
+        uint32_t period = stoi(cmdArgs[1]);
+        float freq = PCA9685::INTERNAL_OSCILLATOR_FREQUENCY;
+        if (cmdArgs.size() == 3) {
+            freq = stof(cmdArgs[2]);
+        }
 
         chip.writeNormalMode();
-        chip.writeDutyTimes(pwm, {period * 1000});
+        chip.writeDutyTimes(pwm, {period * 1000}, freq);
     }
     else if (cmd == "set-duty-ratio") {
-        validateCmdArgc("set-duty", argc, 2);
+        auto cmdArgs = validateCmdArgc(argc, argv, 2);
         auto pwm = stoi(argv[ARG_INDEX_CMD + 1]);
         auto ratio = stof(argv[ARG_INDEX_CMD + 2]);
 

--- a/src/PCA9685Main.cpp
+++ b/src/PCA9685Main.cpp
@@ -136,14 +136,15 @@ int main(int argc, char** argv)
     else if (cmd == "set-duty-us") {
         auto cmdArgs = validateCmdArgc(argc, argv, 2, 3);
         auto pwm = stoi(cmdArgs[0]);
-        uint32_t period = stoi(cmdArgs[1]);
+        uint32_t duty_duration_us = stoi(cmdArgs[1]);
         float freq = PCA9685::INTERNAL_OSCILLATOR_FREQUENCY;
         if (cmdArgs.size() == 3) {
             freq = stof(cmdArgs[2]);
         }
+        uint32_t period = chip.readPWMPeriod(freq);
 
         chip.writeNormalMode();
-        chip.writeDutyTimes(pwm, {period * 1000}, freq);
+        chip.writeDutyTimes(pwm, {duty_duration_us * 1000}, period);
     }
     else if (cmd == "set-duty-ratio") {
         auto cmdArgs = validateCmdArgc(argc, argv, 2);

--- a/src/PCA9685Main.cpp
+++ b/src/PCA9685Main.cpp
@@ -14,7 +14,6 @@ static constexpr int ARG_INDEX_CMD = 3;
 void usage(string const& cmd, ostream& io)
 {
     io << "usage: " << cmd << " DEV ADDRESS CMD [ARGS]\n"
-       << "  set-duty DUTY_CYCLE where DUTY_CYCLE is a float between 0 and 1\n"
        << "  set-period TIME_NS PWM period in nanoseconds\n"
        << "     The command stops PWM generation and put the chip to sleep\n"
        << "  restart perform the PWM generation restart after a sleep\n"
@@ -23,6 +22,9 @@ void usage(string const& cmd, ostream& io)
        << "     The command stops PWM generation and put the chip to sleep\n"
        << "  stop set all PWM outputs to zero\n"
        << "  wakeup wake the chip up after a sleep\n"
+       << "  set-duty-us PWM TIME_US where TIME_US is the ON time in microseconds\n"
+       << "  set-duty-ratio PWM RATIO where RATIO is the ratio of the ON phase of \n"
+       << "       the PWM period, as a float between 0 and 1\n"
        << flush;
 }
 
@@ -83,13 +85,21 @@ int main(int argc, char** argv)
         chip.writeSleepMode();
         chip.writeCycleDuration(duration);
     }
-    else if (cmd == "set-duty") {
+    else if (cmd == "set-duty-us") {
+        validateCmdArgc("set-duty-us", argc, 2);
+        auto pwm = stoi(argv[ARG_INDEX_CMD + 1]);
+        uint32_t period = stoi(argv[ARG_INDEX_CMD + 2]);
+
+        chip.writeNormalMode();
+        chip.writeDutyTimes(pwm, {period * 1000});
+    }
+    else if (cmd == "set-duty-ratio") {
         validateCmdArgc("set-duty", argc, 2);
         auto pwm = stoi(argv[ARG_INDEX_CMD + 1]);
         auto ratio = stof(argv[ARG_INDEX_CMD + 2]);
 
         chip.writeNormalMode();
-        chip.writeDutyCycles(pwm, {ratio});
+        chip.writeDutyRatios(pwm, {ratio});
     }
     else {
         cerr << "invalid command " << cmd << endl;

--- a/src/PCA9685PWMConfiguration.cpp
+++ b/src/PCA9685PWMConfiguration.cpp
@@ -1,0 +1,22 @@
+#include <i2clib/PCA9685PWMConfiguration.hpp>
+
+using namespace i2clib;
+
+/** Convert an off-edge value that might be out of the [0, 4096[ range
+ * into a proper configuration
+ */
+PCA9685PWMConfiguration PCA9685PWMConfiguration::fromUnnormalizedOffEdge(int32_t off_edge)
+{
+    if (off_edge <= 0) {
+        return PCA9685PWMConfiguration{.mode = MODE_OFF};
+    }
+    else if (off_edge >= 4095) {
+        return PCA9685PWMConfiguration{.mode = MODE_ON};
+    }
+
+    PCA9685PWMConfiguration c;
+    c.mode = MODE_NORMAL;
+    c.on_edge = 0;
+    c.off_edge = off_edge;
+    return c;
+}

--- a/src/PCA9685PWMConfiguration.hpp
+++ b/src/PCA9685PWMConfiguration.hpp
@@ -1,0 +1,33 @@
+#ifndef I2CLIB_PWMCONFIGURATION_HPP
+#define I2CLIB_PWMCONFIGURATION_HPP
+
+#include <cstdint>
+
+namespace i2clib {
+    /** Configuration of a single PWM
+     *
+     * on_edge and off_edge are the timing (within a 4096-ticks cycle) of resp.
+     * the off->on transition and on->off transition.
+     *
+     * As such, they can't represent the "full ON" and "full OFF" state. The mode
+     * argument is meant for that.
+     */
+    struct PCA9685PWMConfiguration {
+        enum Mode {
+            MODE_OFF,
+            MODE_ON,
+            MODE_NORMAL
+        };
+
+        Mode mode = MODE_OFF;
+        std::uint16_t on_edge = 0;
+        std::uint16_t off_edge = 0;
+
+        /** Convert an off-edge value that might be out of the [0, 4096[ range
+         * into a proper configuration
+         */
+        static PCA9685PWMConfiguration fromUnnormalizedOffEdge(int32_t off_edge);
+    };
+}
+
+#endif


### PR DESCRIPTION
On top of #1 

ESC and servo input are usually specified in duty time (e.g. 900us). Provide that interface at the API level as well as the CLI for easier manipulation.